### PR TITLE
Make fastest load time a bit faster

### DIFF
--- a/src/Results.js
+++ b/src/Results.js
@@ -52,7 +52,7 @@ const fastLoadTimes = generateDataPoints(
 // load times between 200-500 ms (5% of the data)
 const veryFastLoadTimes = generateDataPoints(
     NUMBER_OF_DATA_POINTS_TO_GENERATE * 0.05,
-    200,
+    50,
     500
 );
 


### PR DESCRIPTION
When a user finds all the samples unacceptable, this can lead to an edge case where the results page says:

> If SLO is based on the fastest "unacceptable" load time, SLO should be "0% of load times should be faster than 0.21 seconds

![IMG_0267](https://github.com/lpmi-13/feeling-slo/assets/464482/3dec002a-56f1-4049-b8fd-dda349a07785)

This is accurate for the sample data, and is a good prompt that sometimes your SLO isn't appropriate for the performance you have, but it's also a bit confusing if you're not familiar with the sample data.

This change makes the fastest sample requests faster, so there should always be at least one that meets the SLO